### PR TITLE
Create Elifine.com workload

### DIFF
--- a/src/aws_organization/workloads.py
+++ b/src/aws_organization/workloads.py
@@ -8,7 +8,7 @@ def create_workloads(
     *,
     org_units: OrganizationalUnits,
     common_workload_kwargs: CommonWorkloadKwargs,
-    workloads: list[AwsWorkload],  # noqa: ARG001 # this arg will eventually be used
+    workloads: list[AwsWorkload],
 ) -> None:
     """Define workloads.
 
@@ -29,3 +29,13 @@ def create_workloads(
     ```
     """
     create_legacy_biotasker(org_units, common_workload_kwargs)
+    workloads.append(
+        AwsWorkload(
+            workload_name="elifine-com",
+            prod_ou=org_units.non_qualified_workload_prod,
+            prod_account_name_suffixes=["production"],
+            dev_ou=org_units.non_qualified_workload_dev,
+            staging_ou=org_units.non_qualified_workload_staging,
+            **common_workload_kwargs,
+        )
+    )


### PR DESCRIPTION
 ## Why is this change necessary?
More robust management of the elifine.com website deployment


 ## How does this change address the issue?
Creates a production account (currently at the 10 account quote limit for the organization...so need to wait for that to expand before creating dev/staging)


 ## What side effects does this change have?
None


 ## How is this change tested?
N/A

